### PR TITLE
Add core logging solution to coredux store.

### DIFF
--- a/library/src/main/kotlin/com/freeletics/coredux/Logging.kt
+++ b/library/src/main/kotlin/com/freeletics/coredux/Logging.kt
@@ -1,0 +1,210 @@
+package com.freeletics.coredux
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.toChannel
+import kotlinx.coroutines.launch
+
+/**
+ * Provides a logging interface to [SideEffect] implementations.
+ *
+ * At least, every [SideEffect] implementation should add logging for [LogEvent.SideEffectEvent.Start],
+ * [LogEvent.SideEffectEvent.InputAction] and [LogEvent.SideEffectEvent.DispatchingToReducer] events.
+ */
+interface SideEffectLogger {
+    /**
+     * Log [LogEvent.SideEffectEvent].
+     */
+    fun logSideEffectEvent(event: () -> LogEvent.SideEffectEvent)
+}
+
+/**
+ * Receiver of log events from store instance.
+ *
+ * Receiving should be fast. Sender has __small__ internal buffer
+ * and on buffer overflow new [LogEntry]s will be dropped
+ * until [LogEntry]s from buffer will be consumed by all [LogSink] instances.
+ *
+ * May be shared between different store instances.
+ */
+interface LogSink {
+    /**
+     * [SendChannel] sink to receive log events.
+     */
+    val sink: SendChannel<LogEntry>
+}
+
+/**
+ * Single log entity.
+ *
+ * @param storeName "unique" store name that was passed as `name` param to [createStore]
+ * @param time [unixtime](https://en.wikipedia.org/wiki/Unix_time) in milliseconds when log event happened
+ * @param event actual event
+ */
+data class LogEntry(
+    val storeName: String,
+    val time: Long,
+    val event: LogEvent
+)
+
+/**
+ * Hierarchy of all possible log events.
+ */
+sealed class LogEvent {
+    /**
+     * Store instance was created.
+     */
+    object StoreCreated : LogEvent()
+
+    /**
+     * Store instance was finished (cancelled).
+     */
+    object StoreFinished : LogEvent()
+
+    /**
+     * All events related to reducer coroutine.
+     */
+    sealed class ReducerEvent : LogEvent() {
+        /**
+         * Reducer coroutine starts.
+         */
+        object Start : ReducerEvent()
+
+        /**
+         * Dispatching new state to [Store] [StateReceiver]s.
+         */
+        data class DispatchState(val state: Any) : ReducerEvent()
+
+        /**
+         * Receiving new input action from [Store].
+         */
+        data class InputAction(
+            val action: Any,
+            val state: Any
+        ) : ReducerEvent()
+
+        /**
+         * Exception in [Reducer] function.
+         */
+        data class Exception(val reason: Throwable) : ReducerEvent()
+
+        /**
+         * Dispatching [action] to all side effects.
+         */
+        data class DispatchToSideEffects(val action: Any) : ReducerEvent()
+    }
+
+    /**
+     * All events related to side effects coroutines.
+     */
+    sealed class SideEffectEvent : LogEvent() {
+        abstract val name: String
+
+        /**
+         * Started side effect coroutine.
+         */
+        data class Start(
+            override val name: String
+        ) : SideEffectEvent()
+
+        /**
+         * Received new input [action] from reducer coroutine.
+         */
+        data class InputAction(
+            override val name: String,
+            val action: Any
+        ) : SideEffectEvent()
+
+        /**
+         * Dispatching new [action] to reducer.
+         */
+        data class DispatchingToReducer(
+            override val name: String,
+            val action: Any
+        ) : SideEffectEvent()
+
+        /**
+         * Custom log event.
+         *
+         * May be used by [SideEffect] implementation to provide custom log events
+         * with [events] payload.
+         */
+        class Custom(
+            override val name: String,
+            vararg val events: Any
+        ) : SideEffectEvent() {
+            override fun toString(): String {
+                val eventsAsString = events.joinToString(",") { it.toString() }
+                return "Custom(name=$name, customEvents=[$eventsAsString])"
+            }
+        }
+    }
+}
+
+@UseExperimental(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+internal class Logger(
+    private val storeName: String,
+    private val scope: CoroutineScope,
+    private val logSinks: List<SendChannel<LogEntry>>
+) : SideEffectLogger {
+    private val inputLogEventsChannel = Channel<LogEntry>(40)
+    private val broadcastChannel = BroadcastChannel<LogEntry>(logSinks.size + 1)
+    private val loggingEnabled = logSinks.isNotEmpty()
+
+    init {
+        if (loggingEnabled) {
+            logSinks.forEach {
+                scope.launch(context = Dispatchers.Default) {
+                    broadcastChannel.openSubscription().toChannel(it)
+                }
+            }
+            scope.launch(context = Dispatchers.Default) {
+                inputLogEventsChannel.toChannel(broadcastChannel)
+            }
+        }
+    }
+
+    internal fun logEvent(event: () -> LogEvent) {
+        if (loggingEnabled) {
+            inputLogEventsChannel.offer(LogEntry(
+                storeName,
+                System.currentTimeMillis(),
+                event()
+            ))
+        }
+    }
+
+    internal fun logAfterCancel(event: () -> LogEvent) {
+        if (loggingEnabled) {
+            // scope is cancelled - using GlobalScope to deliver event
+            GlobalScope.launch {
+                val logEntry = LogEntry(
+                    storeName,
+                    System.currentTimeMillis(),
+                    event()
+                )
+                logSinks.forEach {
+                    it.send(logEntry)
+                }
+            }
+        }
+    }
+
+    override fun logSideEffectEvent(event: () -> LogEvent.SideEffectEvent) {
+        if (loggingEnabled) {
+            inputLogEventsChannel.offer(
+                LogEntry(
+                    storeName,
+                    System.currentTimeMillis(),
+                    event()
+                )
+            )
+        }
+    }
+}

--- a/library/src/main/kotlin/com/freeletics/coredux/SideEffect.kt
+++ b/library/src/main/kotlin/com/freeletics/coredux/SideEffect.kt
@@ -1,5 +1,6 @@
 package com.freeletics.coredux
 
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -18,7 +19,12 @@ typealias StateAccessor<S> = () -> S
  * @param S states type
  * @param A actions type
  */
-interface SideEffect<S, A> {
+interface SideEffect<S : Any, A : Any> {
+    /**
+     * Preferably _unique per store instance_ name for side effect.
+     */
+    val name: String
+
     /**
      * Starts side effect [Job] in given [CoroutineScope].
      *
@@ -33,11 +39,13 @@ interface SideEffect<S, A> {
      * @param stateAccessor provides a way to get current state of [createStore]
      * @param output a [SendChannel] of actions that this side effect should use to produce new actions. If side effect
      * doesn't want to handle new action from [input] channel - it could ignore sending action to this [output] channel
+     * @param logger [SideEffectLogger] instance that should be used to log events
      */
     fun CoroutineScope.start(
         input: ReceiveChannel<A>,
         stateAccessor: StateAccessor<S>,
-        output: SendChannel<A>
+        output: SendChannel<A>,
+        logger: SideEffectLogger
     ) : Job
 }
 
@@ -46,28 +54,47 @@ interface SideEffect<S, A> {
  *
  * @param S states type
  * @param A actions type
+ * @param name unique per store instance side effect name
  * @param sideEffect function should check for given `action`/`state` combination and return either [Job]
  * from `handler {}` coroutine function call or `null`, if side effect does not interested
  * in `action` - `state` combination. If `handler {}` coroutine will be called again on new input,
  * while previous invocation still running - old one coroutine will be cancelled.
  */
-class SimpleSideEffect<S, A>(
+class SimpleSideEffect<S : Any, A : Any>(
+    override val name: String,
     private val sideEffect: (
         state: StateAccessor<S>,
         action: A,
+        logger: SideEffectLogger,
         handler: (suspend () -> A?) -> Job
     ) -> Job?
 ) : SideEffect<S, A> {
+
     override fun CoroutineScope.start(
         input: ReceiveChannel<A>,
         stateAccessor: StateAccessor<S>,
-        output: SendChannel<A>
-    ) = launch {
+        output: SendChannel<A>,
+        logger: SideEffectLogger
+    ) = launch(context = CoroutineName(name)) {
         var job: Job? = null
         for (action in input) {
-            sideEffect(stateAccessor, action) { handler ->
-                job?.cancel()
-                launch { handler()?.let { output.send(it) } }
+            logger.logSideEffectEvent { LogEvent.SideEffectEvent.InputAction(name, action) }
+            sideEffect(stateAccessor, action, logger) { handler ->
+                job?.run {
+                    if (isActive) {
+                        logger.logSideEffectEvent {
+                            LogEvent.SideEffectEvent.Custom(
+                                name,
+                                "Cancelling previous job on new $action action"
+                            )
+                        }
+                    }
+                    cancel()
+                }
+                launch { handler()?.let {
+                    logger.logSideEffectEvent { LogEvent.SideEffectEvent.DispatchingToReducer(name, it) }
+                    output.send(it)
+                } }
             }?.let { job = it }
         }
     }
@@ -78,27 +105,43 @@ class SimpleSideEffect<S, A>(
  *
  * @param S state type
  * @param A action type
+ * @param name unique per store instance side effect name
  * @param sideEffect function should check for given `action`/`state` combination and return either [Job] from
  * `handler {}` function call or `null`, if side effect does not interested in `action`/`state` combination.
  * If `handler {}` function will be called again on new input, while previous returned [Job] is still running -
  * old one [Job] will be cancelled.
  */
-class CancellableSideEffect<S, A>(
+class CancellableSideEffect<S : Any, A : Any>(
+    override val name: String,
     private val sideEffect: (
         state: StateAccessor<S>,
         action: A,
+        logger: SideEffectLogger,
         handler: (CoroutineScope.(SendChannel<A>) -> Unit) -> Job
     ) -> Job?
 ) : SideEffect<S, A> {
+
     override fun CoroutineScope.start(
         input: ReceiveChannel<A>,
         stateAccessor: StateAccessor<S>,
-        output: SendChannel<A>
-    ): Job = launch {
+        output: SendChannel<A>,
+        logger: SideEffectLogger
+    ): Job = launch(context = CoroutineName(name)) {
         var job: Job? = null
         for (action in input) {
-            sideEffect(stateAccessor, action) { handler ->
-                job?.cancel()
+            logger.logSideEffectEvent { LogEvent.SideEffectEvent.InputAction(name, action) }
+            sideEffect(stateAccessor, action, logger) { handler ->
+                job?.run {
+                    if (isActive) {
+                        logger.logSideEffectEvent {
+                            LogEvent.SideEffectEvent.Custom(
+                                name,
+                                "Cancelling previous job on new $action action"
+                            )
+                        }
+                    }
+                    cancel()
+                }
                 launch { handler(output) }
             }?.let { job = it }
         }

--- a/library/src/test/kotlin/com/freeletics/coredux/CancellableSideEffectTest.kt
+++ b/library/src/test/kotlin/com/freeletics/coredux/CancellableSideEffectTest.kt
@@ -16,7 +16,7 @@ object CancellableSideEffectTest : Spek({
     describe("A ${CancellableSideEffect::class.simpleName}") {
         val scope by memoized { CoroutineScope(Dispatchers.Default)}
         val sideEffect by memoized {
-            CancellableSideEffect<String, Int> { state, action, handler ->
+            CancellableSideEffect<String, Int>("test") { state, action, _, handler ->
                 val currentState = state()
                 when {
                     action == 1 && currentState == "" -> handler { output ->
@@ -32,11 +32,12 @@ object CancellableSideEffectTest : Spek({
         val inputChannel by memoized { Channel<Int>() }
         val outputChannel by memoized { Channel<Int>() }
         val stateAccessor by memoized { TestStateAccessor("") }
+        val logger by memoized { StubSideEffectLogger() }
 
         beforeEach {
             scope.launch {
                 with(sideEffect) {
-                    start(inputChannel, stateAccessor, outputChannel)
+                    start(inputChannel, stateAccessor, outputChannel, logger)
                 }
             }
         }

--- a/library/src/test/kotlin/com/freeletics/coredux/SimpleSideEffectTest.kt
+++ b/library/src/test/kotlin/com/freeletics/coredux/SimpleSideEffectTest.kt
@@ -19,7 +19,7 @@ internal object SimpleSideEffectTest : Spek({
     describe("A ${SimpleSideEffect::class.simpleName}") {
         val scope by memoized { CoroutineScope(Dispatchers.Default) }
         val sideEffect by memoized {
-            SE { state, action, handler ->
+            SE("test") { state, action, _, handler ->
                 val currentState = state()
                 when {
                     action == 1 && currentState == "" -> handler {
@@ -33,11 +33,12 @@ internal object SimpleSideEffectTest : Spek({
         val inputChannel by memoized { Channel<Int>() }
         val outputChannel by memoized { Channel<Int>(100) }
         val stateAccessor by memoized { TestStateAccessor("") }
+        val logger by memoized { StubSideEffectLogger() }
 
         beforeEach {
             scope.launch {
                 with (sideEffect) {
-                    start(inputChannel, stateAccessor, outputChannel)
+                    start(inputChannel, stateAccessor, outputChannel, logger)
                 }
             }
         }

--- a/library/src/test/kotlin/com/freeletics/coredux/StoreWithSideEffectsTest.kt
+++ b/library/src/test/kotlin/com/freeletics/coredux/StoreWithSideEffectsTest.kt
@@ -17,6 +17,7 @@ internal object StoreWithSideEffectsTest : Spek({
         val scope by memoized { CoroutineScope(Dispatchers.Default) }
         val store by memoized {
             scope.createStore(
+                name = "Store with one side effect",
                 initialState = "",
                 sideEffects = listOf(stateLengthSE(lengthLimit = 2))
             ) { currentState, newAction ->
@@ -75,16 +76,18 @@ internal object StoreWithSideEffectsTest : Spek({
         val stateReceiver by memoized { TestStateReceiver<String>() }
         val scope by memoized { CoroutineScope(Dispatchers.Default) }
         val loggerSE by memoized { LoggerSE() }
+        val stateLengthSE by memoized { stateLengthSE(lengthLimit = 4, loadDelay = 0L) }
+        val multiplyActionSE by memoized { multiplyActionSE(updateDelay) }
+        val logger by memoized { TestLogger() }
         val store by memoized {
             scope.createStore(
+                name = "Store with many side effects",
                 initialState = "",
+                logSinks = listOf(logger),
                 sideEffects = listOf(
-                    stateLengthSE(
-                        lengthLimit = 4,
-                        loadDelay = 0L
-                    ),
+                    stateLengthSE,
                     loggerSE,
-                    multiplyActionSE(updateDelay)
+                    multiplyActionSE
                 )
             ) { currentState, newAction ->
                 currentState + newAction
@@ -124,6 +127,22 @@ internal object StoreWithSideEffectsTest : Spek({
                         loggerSE.receivedActions
                     )
                 }
+            }
+
+            val expectedLogEvents = listOf(
+                LogEvent.StoreCreated,
+                LogEvent.ReducerEvent.Start,
+                LogEvent.ReducerEvent.DispatchState(""),
+                LogEvent.SideEffectEvent.Start(stateLengthSE.name),
+                LogEvent.SideEffectEvent.Start(loggerSE.name),
+                LogEvent.SideEffectEvent.Start(multiplyActionSE.name),
+                LogEvent.ReducerEvent.InputAction(1, ""),
+                LogEvent.ReducerEvent.DispatchState("1"),
+                LogEvent.ReducerEvent.DispatchToSideEffects(1)
+            )
+
+            it("Should emit log events $expectedLogEvents") {
+                logger.assertLogEvents(*expectedLogEvents.toTypedArray())
             }
 
             context("And after ${updateDelay + 1} delay on second 100 action") {

--- a/library/src/test/kotlin/com/freeletics/coredux/TestsCommon.kt
+++ b/library/src/test/kotlin/com/freeletics/coredux/TestsCommon.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -14,7 +15,7 @@ import org.junit.Assert.assertEquals
 internal fun stateLengthSE(
     lengthLimit: Int = 10,
     loadDelay: Long = 100L
-) = SimpleSideEffect<String, Int> { state, _, handler ->
+) = SimpleSideEffect<String, Int>("stateLengthSE") { state, _, _, handler ->
     val currentStateLength = state().length
     if (currentStateLength <= lengthLimit) {
         handler {
@@ -27,6 +28,8 @@ internal fun stateLengthSE(
 }
 
 class LoggerSE: SideEffect<String, Int> {
+    override val name: String = "LoggerSE"
+
     private val recordedActions = mutableListOf<Int>()
 
     val receivedActions get() = recordedActions.toList()
@@ -34,7 +37,8 @@ class LoggerSE: SideEffect<String, Int> {
     override fun CoroutineScope.start(
         input: ReceiveChannel<Int>,
         stateAccessor: StateAccessor<String>,
-        output: SendChannel<Int>
+        output: SendChannel<Int>,
+        logger: SideEffectLogger
     ) = launch {
         for (action in input) {
             recordedActions.add(action)
@@ -44,7 +48,7 @@ class LoggerSE: SideEffect<String, Int> {
 
 internal fun multiplyActionSE(
     produceDelay: Long = 100L
-) = CancellableSideEffect<String, Int> { _, action, handler ->
+) = CancellableSideEffect<String, Int>("multiplyActionSE") { _, action, _, handler ->
     when (action) {
         in 100..1000 -> handler { output ->
             launch {
@@ -91,4 +95,34 @@ internal class TestStateAccessor<S>(
     fun setCurrentState(state: S) { currentState = state }
 
     override fun invoke(): S = currentState
+}
+
+internal class StubSideEffectLogger : SideEffectLogger {
+    override fun logSideEffectEvent(event: () -> LogEvent.SideEffectEvent) = Unit
+}
+
+internal class TestLogger : LogSink {
+    private val logEvents = mutableListOf<LogEntry>()
+
+    fun receivedLogEntries(count: Int) = runBlocking {
+        withTimeout(1000) {
+            while (logEvents.size < count) {
+                delay(10)
+            }
+            logEvents.toList()
+        }
+    }
+
+    fun assertLogEvents(vararg expected: LogEvent) {
+        val receivedLogEvents = receivedLogEntries(expected.size)
+        expected.forEachIndexed { index, logEntry ->
+            assertEquals(logEntry, receivedLogEvents[index].event)
+        }
+    }
+
+    override val sink: SendChannel<LogEntry> = GlobalScope.actor {
+        while(true) {
+            logEvents.add(receive())
+        }
+    }
 }

--- a/sample/src/main/java/com/freeletics/coredux/businesslogic/pagination/PaginationStateMachine.kt
+++ b/sample/src/main/java/com/freeletics/coredux/businesslogic/pagination/PaginationStateMachine.kt
@@ -181,7 +181,9 @@ class PaginationStateMachine @Inject constructor(
     /**
      * Load the first Page
      */
-    private val loadFirstPageSideEffect = CancellableSideEffect<State, Action> { state, action, handler ->
+    private val loadFirstPageSideEffect = CancellableSideEffect<State, Action>(
+        name = "Load First Page"
+    ) { state, action, _, handler ->
         val currentState = state()
         if (action is Action.LoadFirstPageAction &&
             currentState !is ContainsItems) {
@@ -194,7 +196,9 @@ class PaginationStateMachine @Inject constructor(
     /**
      * A Side Effect that loads the next page
      */
-    private val loadNextPageSideEffect = CancellableSideEffect<State, Action> { state, action, handler ->
+    private val loadNextPageSideEffect = CancellableSideEffect<State, Action>(
+        name = "Load Next Page"
+    ) { state, action, _, handler ->
         when (action) {
             is Action.LoadNextPageAction -> handler { nextPage(state(), it) }
             else -> null
@@ -205,7 +209,9 @@ class PaginationStateMachine @Inject constructor(
      * Shows and hides an error after a given time.
      * In UI a snackbar showing an error message would be shown / hidden respectively
      */
-    private val showAndHideLoadingErrorSideEffect = CancellableSideEffect<State, Action> { _, action, handler ->
+    private val showAndHideLoadingErrorSideEffect = CancellableSideEffect<State, Action>(
+        name = "Show and Hide Loading Error"
+    ) { _, action, _, handler ->
         when {
             action is ErrorLoadingPageAction && action.page > 1 -> handler { output ->
                 launch {
@@ -220,6 +226,7 @@ class PaginationStateMachine @Inject constructor(
 
     fun create(coroutineScope: CoroutineScope): Store<State, Action> = coroutineScope
         .createStore(
+            name = "Pagination State Machine",
             initialState = State.LoadingFirstPageState,
             sideEffects = listOf(
                 loadFirstPageSideEffect,


### PR DESCRIPTION
Initial iteration on logging support for CoRedux with following ideas in mind:
- Solution just provide a way to receive logs without actual implementation (library may provide separate artifacts with particular implementations)
- Logging should be lazy and be enabled only when one or more `LogSink` was provided (kind of inspired by https://github.com/MicroUtils/kotlin-logging)
- Logging should be non-blocking and may loose log entries in worst cases (burst of log events, while `LogSink` is slow)

@sockeqwe @fraherm I want to hear your opinions on this implementation before I will polish it :bowing_man: 

To see how it works use following code:
```kotlin
class PrintlnLogSink(
    scope: CoroutineScope
) : LogSink {
    private var initTime: Long = 0

    private val _sink: SendChannel<LogEntry> = scope.actor(context = Dispatchers.IO) {
        while (true) {
            val message = receive()
            if (message.event == LogEvent.StoreCreated) {
                initTime = message.time
            }
            println("${timeDiff(message.time)} LOG ENTRY: $message")
        }
    }
    override val sink: SendChannel<LogEntry>
        get() = _sink

    private fun timeDiff(currentTime: Long): String = "+${currentTime - initTime}ms"
}

fun main() {
    val scope = CoroutineScope(Dispatchers.Default)
    val additionSideEffect = SimpleSideEffect<String, Int>("additionSE") { state, action, handler ->
        if (action <= 5) handler { action + 50 }
        else null
    }
    val logSink = PrintlnLogSink(GlobalScope)
    val store = scope.createStore(
        name = "TestStore",
        initialState = "init",
        sideEffects = listOf(additionSideEffect),
        logSinks = listOf(logSink)
    ) { _, newAction ->
        newAction.toString()
    }

    store.subscribe { println("${System.currentTimeMillis()}: Received new state: $it") }

    scope.launch {
        (0..5).forEach {
            delay(10)
            store.dispatch(it)
        }
    }

    runBlocking {
        delay(2000)
        scope.cancel()
        delay(100)
    }
}
```