### PR TITLE
Fix flaky test

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -26,7 +26,7 @@ ext.versions = [
 
         junit                  : '4.12',
         junit5                 : '1.3.2',
-        spek2                  : '2.0.0-rc.1',
+        spek2                  : '2.0.1',
         kotlinMockito          : '1.5.0',
         assertJ                : '3.8.0',
         espresso               : '3.0.2',

--- a/library/core/src/test/kotlin/com/freeletics/coredux/SimpleStoreTest.kt
+++ b/library/core/src/test/kotlin/com/freeletics/coredux/SimpleStoreTest.kt
@@ -119,7 +119,7 @@ object SimpleStoreTest : Spek({
                     context("and when second subscriber subscribes after 1 ms") {
                         beforeEach {
                             runBlocking {
-                                delay(1)
+                                delay(10)
                                 store.subscribe(secondStateReceiver)
                             }
                         }


### PR DESCRIPTION
Increase delay that second consumer waits for subscribing to the store. This reduces changes that it will receive not-yet-emitted states.

To test run:
```sh
$ for i in `seq 20`; do ./gradlew :library:core:test --rerun-tasks; sleep .5; done
```

Fixes #10 