### PR TITLE
Log custom event message

### DIFF
--- a/library/log/common/src/main/kotlin/com/freeletics/coredux/log/common/LoggerLogSink.kt
+++ b/library/log/common/src/main/kotlin/com/freeletics/coredux/log/common/LoggerLogSink.kt
@@ -76,7 +76,7 @@ abstract class LoggerLogSink(
         )
         is LogEvent.SideEffectEvent.Custom -> storeName.logWithTimeDiff(
             timeDiff,
-            "[(SE) ${event.name}] $event",
+            "[(SE) ${event.name}] ${event.event}",
             logger = ::debug
         )
     }


### PR DESCRIPTION
Currently it prints the class instance of `LogEvent.SideEffectEvent.Custom`.