### PR TITLE
Migrate tests to use TestCoroutineScope.

### DIFF
--- a/library/core/src/main/kotlin/com/freeletics/coredux/Logging.kt
+++ b/library/core/src/main/kotlin/com/freeletics/coredux/Logging.kt
@@ -2,7 +2,6 @@ package com.freeletics.coredux
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.ObsoleteCoroutinesApi
@@ -146,7 +145,7 @@ internal class Logger(
     private val storeName: String,
     scope: CoroutineScope,
     private val logSinks: List<SendChannel<LogEntry>>,
-    toLogSinksDispatcher: CoroutineDispatcher = Dispatchers.Default
+    toLogSinksDispatcher: CoroutineDispatcher
 ) : SideEffectLogger {
     private val inputLogEventsChannel = Channel<LogEntry>(40)
     private val loggingEnabled = logSinks.isNotEmpty()

--- a/library/core/src/test/kotlin/com/freeletics/coredux/CancellableSideEffectTest.kt
+++ b/library/core/src/test/kotlin/com/freeletics/coredux/CancellableSideEffectTest.kt
@@ -1,27 +1,29 @@
 package com.freeletics.coredux
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
-import org.junit.Assert.fail
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val DEFAULT_DELAY_MS = 10L
+
+@ExperimentalCoroutinesApi
 object CancellableSideEffectTest : Spek({
     describe("A ${CancellableSideEffect::class.simpleName}") {
-        val scope by memoized { CoroutineScope(Dispatchers.Default)}
+        val testScope by memoized { TestCoroutineScope() }
         val sideEffect by memoized {
             CancellableSideEffect<String, Int>("test") { state, action, _, handler ->
                 val currentState = state()
                 when {
                     action == 1 && currentState == "" -> handler { _, output ->
                         launch {
-                            delay(10)
+                            delay(DEFAULT_DELAY_MS)
                             (2..4).forEach { output.send(it) }
                         }
                     }
@@ -35,89 +37,75 @@ object CancellableSideEffectTest : Spek({
         val logger by memoized { StubSideEffectLogger() }
 
         beforeEach {
-            scope.launch {
+            testScope.launch {
                 with(sideEffect) {
                     start(inputChannel, stateAccessor, outputChannel, logger)
                 }
             }
         }
 
+        afterEach { testScope.cleanupTestCoroutines() }
+
         context("when current state is not \"\"") {
             beforeEach { stateAccessor.setCurrentState("some-other-state") }
 
             context("and on new 1 action") {
-                beforeEach { scope.launch { inputChannel.send(1) } }
+                beforeEach {
+                    testScope.launch { inputChannel.send(1) }
+                    testScope.advanceTimeBy(DEFAULT_DELAY_MS + 1)
+                }
 
-                it("should not call handler") {
-                    runBlocking {
-                        try {
-                            withTimeout(100) {
-                                val item = outputChannel.receive()
-                                fail("Received $item")
-                            }
-                        } catch (e: TimeoutCancellationException) {}
-                    }
+                it("should not call handler function") {
+                    assertTrue(outputChannel.isEmpty)
                 }
             }
         }
 
         context("when current state is \"\"") {
             context("and on new 2 action") {
-                beforeEach { scope.launch { inputChannel.send(2) } }
+                beforeEach {
+                    testScope.launch { inputChannel.send(2) }
+                    testScope.advanceTimeBy(DEFAULT_DELAY_MS + 1)
+                }
 
-                it("should not call handler") {
-                    runBlocking {
-                        try {
-                            withTimeout(30) {
-                                val item = outputChannel.receive()
-                                fail("Received $item")
-                            }
-                        } catch (e: TimeoutCancellationException) {}
-                    }
+                it("should not call handler function") {
+                    assertTrue(outputChannel.isEmpty)
                 }
             }
         }
 
         context("and on new 1 action") {
-            beforeEach { scope.launch { inputChannel.send(1) } }
+            beforeEach { testScope.launch { inputChannel.send(1) } }
 
             it("should send 2, 3, 4 actions to output channel") {
-                runBlocking {
-                    withTimeout(30) {
-                        val items = mutableListOf<Int>()
-                        while (items.size < 3) {
-                            items.add(outputChannel.receive())
-                        }
-                    }
+                val items = mutableListOf<Int>()
+                repeat(3) {
+                    testScope.advanceTimeBy(DEFAULT_DELAY_MS)
+                    testScope.runBlockingTest { items.add(outputChannel.receive()) }
                 }
+                assertEquals(listOf(2, 3, 4), items.toList())
             }
 
             context("and on second immediate 1 action") {
-                beforeEach { scope.launch { inputChannel.send(1) } }
+                beforeEach { testScope.launch { inputChannel.send(1) } }
 
                 it("should send 2, 3, 4 actions to output channel") {
-                    runBlocking {
-                        withTimeout(30) {
-                            val items = mutableListOf<Int>()
-                            while (items.size < 3) {
-                                items.add(outputChannel.receive())
-                            }
-                        }
+                    val items = mutableListOf<Int>()
+                    repeat(3) {
+                        testScope.advanceTimeBy(DEFAULT_DELAY_MS)
+                        testScope.runBlockingTest { items.add(outputChannel.receive()) }
                     }
+                    assertEquals(listOf(2, 3, 4), items.toList())
                 }
 
                 it("should cancel previous call to handler function") {
-                    runBlocking {
-                        try {
-                            withTimeout(100) {
-                                val items = mutableListOf<Int>()
-                                while (items.size < 10) {
-                                    items.add(outputChannel.receive())
-                                }
-                                fail("Received more actions then expected: $items")
-                            }
-                        } catch (e: TimeoutCancellationException) {}
+                    val items = mutableListOf<Int>()
+                    repeat(5) {
+                        testScope.advanceTimeBy(DEFAULT_DELAY_MS)
+                        outputChannel.poll()?.let { items.add(it) }
                     }
+                    assertEquals(3, items.size)
+                    assertTrue(outputChannel.isEmpty)
                 }
             }
         }

--- a/library/core/src/test/kotlin/com/freeletics/coredux/LoggerTest.kt
+++ b/library/core/src/test/kotlin/com/freeletics/coredux/LoggerTest.kt
@@ -10,7 +10,7 @@ import org.spekframework.spek2.style.specification.describe
 class LoggerTest : Spek({
     describe("A Logger") {
         val storeName = "some-store"
-        val coroutineScope by memoized { TestCoroutineScope() }
+        val testScope by memoized { TestCoroutineScope() }
         val loggerDispatcher by memoized { TestCoroutineDispatcher() }
         val testLogSinks by memoized {
             listOf(
@@ -20,11 +20,13 @@ class LoggerTest : Spek({
             )
         }
 
+        afterEach { testScope.cleanupTestCoroutines() }
+
         context("when log sinks are available") {
             val logger by memoized {
                 Logger(
                     storeName,
-                    coroutineScope,
+                    testScope,
                     testLogSinks.map { it.sink },
                     loggerDispatcher
                 )

--- a/library/core/src/test/kotlin/com/freeletics/coredux/LoggerTest.kt
+++ b/library/core/src/test/kotlin/com/freeletics/coredux/LoggerTest.kt
@@ -15,13 +15,12 @@ class LoggerTest : Spek({
         val testScope by memoized { TestCoroutineScope() }
         val loggerDispatcher by memoized { TestCoroutineDispatcher() }
         val testLoggers by memoized { listOf(
-            TestLogger(),
-            TestLogger(),
-            TestLogger()
+            TestLogger(testScope),
+            TestLogger(testScope),
+            TestLogger(testScope)
         ) }
 
         afterEach {
-            testLoggers.forEach { it.close() }
             testScope.cleanupTestCoroutines()
         }
 

--- a/library/core/src/test/kotlin/com/freeletics/coredux/StoreWithSideEffectsTest.kt
+++ b/library/core/src/test/kotlin/com/freeletics/coredux/StoreWithSideEffectsTest.kt
@@ -2,6 +2,8 @@ package com.freeletics.coredux
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -11,6 +13,8 @@ import org.junit.Assert.fail
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+@ObsoleteCoroutinesApi
+@ExperimentalCoroutinesApi
 internal object StoreWithSideEffectsTest : Spek({
     describe("A redux store with only ${::stateLengthSE.name} side effect") {
         val stateReceiver by memoized { TestStateReceiver<String>() }
@@ -96,8 +100,13 @@ internal object StoreWithSideEffectsTest : Spek({
 
         beforeEach { store.subscribe(stateReceiver) }
 
+        afterEach { logger.close() }
+
         context("On 1 action") {
-            beforeEach { store.dispatch(1) }
+            beforeEach {
+                store.dispatch(1)
+                logger.waitForLogEntries(9)
+            }
 
             val expectedStates = listOf(
                 "",


### PR DESCRIPTION
Migrate all unit tests in `:library:core` to use `TestCoroutineScope`, that executes coroutines immediately and allows to advance time manually. Such approach should make tests more reliable and reduce flakyness.

More info about `TestCoroutineScope` could be found here: https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/README.md